### PR TITLE
fix: use subscription fields as string

### DIFF
--- a/src/calls/event/__tests__/event.test.ts
+++ b/src/calls/event/__tests__/event.test.ts
@@ -127,7 +127,7 @@ describe('activity class', () => {
     const subscription = await client.createSubscription({
       event: 'project.create',
       targetUrl: 'http://example.com',
-      fields: ['id', 'name', 'number', 'isClosed'],
+      fields: 'id,name,number,isClosed',
     });
 
     parseRuntypeValidationError(subscription.error);

--- a/src/calls/event/types.ts
+++ b/src/calls/event/types.ts
@@ -19,7 +19,7 @@ export interface CreateSubscriptionInput {
    * The fields in the object delivered
    * with the notification callback, nested as in other API calls.
    */
-  fields?: string[];
+  fields?: string;
 
   /**
    * Custom authentication header name


### PR DESCRIPTION
## TL;DR

according to [tripletex api](https://tripletex.no/v2-docs/#/event%2Fsubscription/EventSubscription_post), the /event/subscirption expects the `field`to be a string rather than an array

## What's changed

* turned subscription events endpoint to expect string 

## Why

This is to make the subscription use the expected input to avoid getting 422 errors.